### PR TITLE
ci: switch releases to be own by Lacework releng ⚡

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,13 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "6a:1b:3f:38:f4:02:07:5a:fa:52:fc:20:f6:46:8c:75"
+            - "78:88:2e:20:f7:a3:2c:72:c1:02:30:39:14:c3:00:f7"
+      - slack/notify:
+          mentions: << pipeline.parameters.slack-mentions >>
+          message: Updating homebrew-tap formula
       - run: make update-cli-version
+      - slack/status:
+          mentions: << pipeline.parameters.slack-mentions >>
   test:
     executor: brew-exec
     steps:

--- a/scripts/update-cli-version.sh
+++ b/scripts/update-cli-version.sh
@@ -2,8 +2,8 @@
 
 readonly package_name=lacework-cli
 readonly cli_formula=Formula/lacework-cli.rb
-readonly git_user="Darren Murray"
-readonly git_email="darren.murray@lacework.net"
+readonly git_user="Lacework Inc."
+readonly git_email="ops+releng@lacework.net"
 
 TARGETS=(
   ${package_name}-darwin-amd64.zip
@@ -46,7 +46,7 @@ push_update_formula() {
   echo "commiting and pushing the updated formula to github"
   git config --global user.email $git_email
   git config --global user.name $git_user
-  git commit -am "chore: Update lacework-cli formula to $1"
+  git commit -am "ci: update lacework-cli formula to $1"
   git push origin main
 }
 


### PR DESCRIPTION
As a Lacework Engineer,
I would like to use an in-house Github account to set up all releases and pipelines
So I don't have to use my personal Github account.

## Description
We are starting to use the company's Github account https://github.com/lacework-releng to do
our automated releases.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>