### PR TITLE
ci: apply lint changes in update script

### DIFF
--- a/scripts/update-cli-version.sh
+++ b/scripts/update-cli-version.sh
@@ -27,6 +27,7 @@ main() {
         replace_sha_sum $version $target
     done
 
+    lint
     push_update_formula $version
 }
 
@@ -51,4 +52,9 @@ push_update_formula() {
   git push origin main
 }
 
+lint() {
+  brew audit --formula $cli_formula --strict --fix
+}
+
 main "$@"
+


### PR DESCRIPTION
Resolves issue: https://lacework.atlassian.net/browse/ALLY-573

The brew audit step in codefresh was failing due to bad indentation after the update script runs. This change includes the lint auto apply in the update script.

Signed-off-by: Darren Murray <darren.murray@lacework.net>