### PR TITLE
ci: remove brew audit

### DIFF
--- a/scripts/update-cli-version.sh
+++ b/scripts/update-cli-version.sh
@@ -21,7 +21,7 @@ main() {
   currentVersion=$(cat "$cli_formula" | grep 'VERSION = '| sed 's/.*VERSION = "\(.*\)".freeze/\1/')
 
   [[ $version != $currentVersion ]] || { echo >&2 "Formula is already on latest version"; exit 1; }
-    
+
   echo "Updating current: $currentVersion with latest: $version"
   update_version $currentVersion $version
 
@@ -29,7 +29,6 @@ main() {
       replace_sha_sum $version $target
   done
 
-  lint
   push_update_formula $version
 }
 
@@ -63,10 +62,6 @@ push_update_formula() {
   fi
   git commit -sS -am "ci: update lacework-cli formula to $1"
   git push origin main
-}
-
-lint() {
-  brew audit --formula "$cli_formula" --strict --fix
 }
 
 main "$@"


### PR DESCRIPTION
We're getting the following error on newer version of homebrew: `brew audit [path ...] is disabled! Use brew audit [name ...] instead`. Meaning we have to create a local tap to audit. This PR removes the `brew audit` step from the `update-cli-version` script.

`brew audit` will be moved to the workflow by this PR https://github.com/lacework/go-sdk/pull/1575